### PR TITLE
Added discount adjustments on order level to klarna calculation 

### DIFF
--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -217,6 +217,36 @@ class Gateway extends OffsiteGateway
                             ],
                         ];
                     }
+
+                    // Add order-level discount adjustments that are not included in line items
+                    $adjustments = $transaction->getOrder()->getAdjustments();
+                    foreach ($adjustments as $adjustment) {
+                        if ($adjustment->type !== 'discount' ||
+                            $adjustment->included ||
+                            $adjustment->lineItemId !== null
+                        ) {
+                            continue;
+                        }
+
+                        $amount = $adjustment->amount;
+                        if ($amount >= 0) {
+                            continue;
+                        }
+
+                        $requestData['lines'][] = [
+                            'description' => $adjustment->name ?: Craft::t('commerce', 'Order discount'),
+                            'type' => 'discount',
+                            'quantity' => 1,
+                            'unitPrice' => [
+                                'currency' => $currency,
+                                'value' => $teller->convertToString($amount),
+                            ],
+                            'totalAmount' => [
+                                'currency' => $currency,
+                                'value' => $teller->convertToString($amount),
+                            ],
+                        ];
+                    }
                 }
 
                 // Required for Alma payment method

--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -9,11 +9,13 @@ namespace craft\commerce\mollie\gateways;
 
 use Craft;
 use craft\base\Event;
+use craft\commerce\adjusters\Discount;
 use craft\commerce\base\RequestResponseInterface;
 use craft\commerce\elements\Order;
 use craft\commerce\errors\CurrencyException;
 use craft\commerce\errors\OrderStatusException;
 use craft\commerce\errors\TransactionException;
+use craft\commerce\models\OrderAdjustment;
 use craft\commerce\models\payments\BasePaymentForm;
 use craft\commerce\models\Transaction;
 use craft\commerce\mollie\models\forms\MollieOffsitePaymentForm;
@@ -177,7 +179,8 @@ class Gateway extends OffsiteGateway
                 // Lines for Klarna
                 if ($requestData['method'] === 'klarna') {
                     $requestData['lines'] = [];
-                    $lineItems = $transaction->getOrder()->getLineItems();
+                    $order = $transaction->getOrder();
+                    $lineItems = $order->getLineItems();
                     $currency = $transaction->paymentCurrency;
 
                     $teller = Plugin::getInstance()->getCurrencies()->getTeller($currency);
@@ -201,10 +204,10 @@ class Gateway extends OffsiteGateway
                     }
 
                     // Add shipping line item if it exists
-                    $shippingCost = $transaction->getOrder()->getTotalShippingCost();
+                    $shippingCost = $order->getTotalShippingCost();
                     if ($shippingCost > 0) {
                         $requestData['lines'][] = [
-                            'description' => $transaction->getOrder()->shippingMethodName,
+                            'description' => $order->shippingMethodName,
                             'type' => 'shipping_fee',
                             'quantity' => 1,
                             'unitPrice' => [
@@ -218,32 +221,26 @@ class Gateway extends OffsiteGateway
                         ];
                     }
 
-                    // Add order-level discount adjustments that are not included in line items
-                    $adjustments = $transaction->getOrder()->getAdjustments();
-                    foreach ($adjustments as $adjustment) {
-                        if ($adjustment->type !== 'discount' ||
-                            $adjustment->included ||
-                            $adjustment->lineItemId !== null
-                        ) {
-                            continue;
-                        }
+                    // In core Commerce operation it is not possible to have an order level discount.
+                    // Those discount types spread their cost across the line items to make sure things like tax is calculated correctly.
+                    // The following code is to allow anyone registering a custom order level discount to be sent to Klarna.
+                    $discountAdjustments = array_filter($order->getAdjustmentsByType(Discount::ADJUSTMENT_TYPE), function(OrderAdjustment $adjustment) {
+                        return !$adjustment->included && $adjustment->lineItemId === null && $adjustment->amount < 0;
+                    });
 
-                        $amount = $adjustment->amount;
-                        if ($amount >= 0) {
-                            continue;
-                        }
-
+                    foreach ($discountAdjustments as $adjustment) {
+                        $value = $teller->convertToString($adjustment->amount);
                         $requestData['lines'][] = [
-                            'description' => $adjustment->name ?: Craft::t('commerce', 'Order discount'),
+                            'description' => $adjustment->description ?: Craft::t('commerce', 'Discount'),
                             'type' => 'discount',
                             'quantity' => 1,
                             'unitPrice' => [
                                 'currency' => $currency,
-                                'value' => $teller->convertToString($amount),
+                                'value' => $value,
                             ],
                             'totalAmount' => [
                                 'currency' => $currency,
-                                'value' => $teller->convertToString($amount),
+                                'value' => $value,
                             ],
                         ];
                     }


### PR DESCRIPTION
### Description
When verifying the order amount for Klarna when creating a payment request, the discount adjustments that we attached on order level instead of the line-item where not taken in account. This would end up with a 422 error: 'Unprocessable Entity: The amount field is off. Expected to be ....'.

Checked for discount adjustments that are not already are included and don't have a lineItemId. Tested some various discount combinations and that seemed fine. Can you check if I missed something? Thanks

### Related issues
https://github.com/craftcms/commerce-mollie/issues/75
